### PR TITLE
fix(build): add resolve extension param in WP configuration

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -18,6 +18,7 @@ export default {
     filename: '[name].js'
   },
   resolve: {
+    extensions: [".js", ".json", ".less"],
     alias: {
       src: path.resolve(__root, 'src'),
       build: path.resolve(__dirname),


### PR DESCRIPTION
Signed-off-by: Kevin Manson kevin.manson@corp.ovh.com

Build was ok on osx, but broken on linux.