### PR TITLE
feat(indeterminate): new directive to active indeterminate mode on checkboxes

### DIFF
--- a/src/components/indeterminate.directive.js
+++ b/src/components/indeterminate.directive.js
@@ -1,0 +1,11 @@
+export default () => ({
+  restrict: 'A',
+  link: ($scope, $element, $attrs) => {
+    const tagName = $element.prop('tagName')
+    const type = $element.attr('type')
+
+    if (tagName && type && tagName.toLowerCase() === 'input' && type.toLowerCase() === 'checkbox') {
+      $element.prop('indeterminate', true)
+    }
+  }
+})

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,5 @@
+import IndeterminateDirective from './indeterminate.directive'
+
+export default angular
+  .module('ovh-ui-kit-documentation-components', [])
+  .directive('indeterminate', IndeterminateDirective)

--- a/src/index.js
+++ b/src/index.js
@@ -14,11 +14,14 @@ import DocumentationRoutes from './documentation/documentation.routes'
 import OvhUiKitRoutes from './ovh-ui-kit/ovh-ui-kit.routes'
 import OvhUiAngularRoutes from './ovh-ui-angular/ovh-ui-angular.routes'
 
+import './components'
+
 const app = angular
   .module('ovh-ui-kit-documentation', [
     'ui.router',
     'ovh-documentation-toolkit',
-    'oui'
+    'oui',
+    'ovh-ui-kit-documentation-components'
   ])
   .config(themesConfig)
   .config(versionsConfig)


### PR DESCRIPTION
Signed-off-by: Jimmy Fortin <jimmy.fortin@corp.ovh.com>

This directive is only used from `ovh-ui-kit` to active the indeterminate mode on checkboxes.