### PR TITLE
fix html inside markdown

### DIFF
--- a/build/loaders/markdown-renderer.js
+++ b/build/loaders/markdown-renderer.js
@@ -20,7 +20,9 @@ export default class extends marked.Renderer {
   // - Removes every element and its children with oui-doc-preview-only class on it
   // - Removes only the element with oui-doc-preview-only-keep-children class on it
   _filterHtmlElementFromCode (code) {
-    const $ = cheerio.load(code)
+    const $ = cheerio.load(code, {
+      decodeEntities: false
+    })
 
     $('.oui-doc-preview-only').remove()
     $('.oui-doc-preview-only-keep-children').replaceWith(function () {

--- a/build/loaders/markdown-renderer.js
+++ b/build/loaders/markdown-renderer.js
@@ -29,7 +29,10 @@ export default class extends marked.Renderer {
       return $(this).html()
     })
 
-    return $('body').html()
+    // HACK: Known issue on Cheerio and it is not cleared if it will be fixed.
+    // `.replace(/=""/g, '')`
+    // https://github.com/cheeriojs/cheerio/issues/1032
+    return $('body').html().replace(/=""/g, '')
   }
 
   code (code, lang) {


### PR DESCRIPTION
It fixes preview code like that:

```html
<oui-action-menu-item text="Action 1" aria-label="Server: action 1" on-click="$ctrl.showCurrentValueInPopup(&apos;Action 1&apos;)"></oui-action-menu-item>
```

where it should looks like

```html
<oui-action-menu-item text="Action 1" aria-label="Server: action 1" on-click="$ctrl.showCurrentValueInPopup('Action 1')"></oui-action-menu-item>
```

Also, empty value inside attribute where append by `=""`:

```html
<oui-action-menu-item text="Lien externe" href="#" external=""></oui-action-menu-item>
```

where it should looks like

```html
<oui-action-menu-item text="Lien externe" href="#" external></oui-action-menu-item>
```

You can compare http://master.ui-kit.ovh/#!/oui-angular/action-menu and http://fix_html_inside_markdown.ui-kit.ovh/#!/oui-angular/action-menu