### PR TITLE
chore(oui-calendar): bump flatpickr version to v4.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "angular-messages": "^1.6.1",
     "angular-sanitize": "^1.6.1",
     "angular-ui-router": "^0.4.2",
-    "flatpickr": "~4.3.2",
+    "flatpickr": "~4.4.3",
     "lodash": "^4.17.4",
     "ovh-documentation-toolkit": "^1.0.0",
     "ovh-ui-angular": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "angular-messages": "^1.6.1",
     "angular-sanitize": "^1.6.1",
     "angular-ui-router": "^0.4.2",
-    "flatpickr": "~4.4.3",
+    "flatpickr": "4.4.4",
     "lodash": "^4.17.4",
     "ovh-documentation-toolkit": "^1.0.0",
     "ovh-ui-angular": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,9 +3001,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flatpickr@~4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.3.2.tgz#6a477043c075ef36c3ff54fadb49b936a64d635f"
+flatpickr@~4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.4.3.tgz#53ba7b06523f73ee69175b3ed808c7fc0f245c4f"
 
 flatten@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
UU-778

* Bump flatpickr to v4.4.3

http://build_oui_field_calendar.ui-kit.ovh/#!/oui-angular/calendar
http://build_oui_field_calendar.ui-kit.ovh/#!/oui-angular/field

**Linked to**
https://github.com/ovh-ux/ovh-ui-angular/pull/146
https://github.com/ovh-ux/ovh-ui-kit/pull/180