### PR TITLE
chore(oui-radio): remove group and toggle-group pages

### DIFF
--- a/src/ovh-ui-angular/ovh-ui-angular.config.json
+++ b/src/ovh-ui-angular/ovh-ui-angular.config.json
@@ -28,12 +28,6 @@
     "group": "form"
   },
   "radio": {
-    "group": "internal"
-  },
-  "radio-group": {
-    "group": "form"
-  },
-  "radio-toggle-group": {
     "group": "form"
   },
   "textarea": {


### PR DESCRIPTION
* Remove `oui-radio-group` and `oui-radio-toggle-group` pages from config

Linked to https://github.com/ovh-ux/ovh-ui-angular/pull/257