### PR TITLE
style: update markdown renderer for preview

### DIFF
--- a/build/loaders/markdown-renderer.js
+++ b/build/loaders/markdown-renderer.js
@@ -53,16 +53,21 @@ export default class extends marked.Renderer {
                         Click to show the example
                     </oui-button>
                 </p>
-                <div class="oui-showcase__code"
-                     ng-show="${scopeVariableName}">
-                    <pre ng-non-bindable>${highlightCode}</pre>
-                </div>`
-            } else {
-                highlightCode = highlight.highlight(lang, code).value
+                <div ng-show="${scopeVariableName}">
+                    <pre class="oui-doc-code" ng-non-bindable>${highlightCode}</pre>
+                </div>`;
             }
+
+            highlightCode = highlight.highlight(lang, code).value;
+
+            return `<pre class="oui-doc-code oui-doc-code_${lang}">${highlightCode}</pre>`;
         }
 
-        return `<pre class="oui-showcase__code">${highlightCode}</pre>`
+        return `<pre class="oui-doc-code">${highlightCode}</pre>`;
+    }
+
+    codespan (code) {
+        return `<code class="oui-doc-codespan">${code}</code>`;
     }
 
     table (header, body) {

--- a/src/index.less
+++ b/src/index.less
@@ -26,5 +26,5 @@ pre, samp {
 }
 
 .oui-doc-codespan {
-    color: @oui-color-error-dark;
+    color: @oui-color-pomegranate;
 }

--- a/src/index.less
+++ b/src/index.less
@@ -10,13 +10,21 @@
 themes-selector,
 versions-selector { display: none; }
 
-.oui-doc-preview { margin-bottom: rem-calc(15); }
+code, kbd,
+pre, samp {
+    font-size: 87.5%;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
 
-.oui-showcase__code {
-    pre,
-    pre& {
-        &:extend(.oui-box);
-    }
+.oui-doc-code,
+.oui-doc-preview {
+    margin: 0 0 rem-calc(15);
+}
 
-    pre { margin: 0; }
+.oui-doc-code {
+    &:extend(.oui-box);
+}
+
+.oui-doc-codespan {
+    color: @oui-color-error-dark;
 }


### PR DESCRIPTION
* add variant classname on `oui-doc-code` block for better styling according to its content
* add template for `codespan`